### PR TITLE
Update default-crypto-instances.ts

### DIFF
--- a/src/lib/crypto/default-crypto-instances.ts
+++ b/src/lib/crypto/default-crypto-instances.ts
@@ -3,13 +3,11 @@ import { instantiateSecp256k1 } from './secp256k1.js';
 import { instantiateSha1 } from './sha1.js';
 import { instantiateSha256 } from './sha256.js';
 import { instantiateSha512 } from './sha512.js';
-
-const [sha1, sha256, sha512, ripemd160, secp256k1] = await Promise.all([
-  instantiateSha1(),
-  instantiateSha256(),
-  instantiateSha512(),
-  instantiateRipemd160(),
-  instantiateSecp256k1(),
-]);
+let ripemd160,secp256k1,sha1,sha256, sha512;
+instantiateRipemd160()  .then(a => ripemd160 = a);
+instantiateSecp256k1()  .then(b => secp256k1 = b);
+instantiateSha1()       .then(c => sha1 = c);
+instantiateSha256()     .then(d => sha256 = d);
+instantiateSha512()     .then(e => sha512 = e);
 
 export { ripemd160, secp256k1, sha1, sha256, sha512 };


### PR DESCRIPTION
The latest React projects complains the existing code has a top level await. This proposed change returns the same variables but not as promises.
The code may look a little "hacky" but the traditional way of solving is issue using  IIFE doesn't work.
ie: this doesn't work:
  (async() => {
const [sha1, sha256, sha512, ripemd160, secp256k1] = await Promise.all([
    instantiateSha1(),
    instantiateSha256(),
    instantiateSha512(),
    instantiateRipemd160(),
    instantiateSecp256k1(),
]);
})();
export { ripemd160, secp256k1, sha1, sha256, sha512 };