### PR TITLE
Validate decodePrivateKeyWif version and length

### DIFF
--- a/src/lib/key/wallet-import-format.spec.ts
+++ b/src/lib/key/wallet-import-format.spec.ts
@@ -8,12 +8,37 @@ import {
   encodePrivateKeyWif,
   hexToBin,
   sha256 as internalSha256,
+  WalletImportFormatError,
 } from '../lib.js';
 
 test('decodePrivateKeyWif: pass through errors', (t) => {
   t.deepEqual(
     decodePrivateKeyWif('not a key'),
     `${Base58AddressError.unknownCharacter} ${BaseConversionError.unknownCharacter} Unknown character: " ".`,
+  );
+});
+
+test('decodePrivateKeyWif: invalid version (base58/legacy address)', (t) => {
+  t.deepEqual(
+    // cspell: disable-next-line
+    decodePrivateKeyWif('1CQbfkN8cADaJWk29ARtaa55UNdBa1kLaA'),
+    WalletImportFormatError.invalidVersion,
+  );
+});
+
+test('decodePrivateKeyWif: incorrect length (mainnet wif version, 20 bytes)', (t) => {
+  t.deepEqual(
+    // cspell: disable-next-line
+    decodePrivateKeyWif('tWGD2u9st6K9gUr68hdo53qhZZyk3JoQAF'),
+    WalletImportFormatError.incorrectLength,
+  );
+});
+
+test('decodePrivateKeyWif: incorrect length (testnet wif version, 20 bytes)', (t) => {
+  t.deepEqual(
+    // cspell: disable-next-line
+    decodePrivateKeyWif('2fAnAKxErh7kQTbKhrGcAty42RZaSyLdLhp'),
+    WalletImportFormatError.incorrectLength,
   );
 });
 


### PR DESCRIPTION
The `decodePrivateKeyWif` function will currently allow a Legacy/Base58 BTC address.

For example:

```
// Using Base58/Legacy Address
const decodedPrivateKey = decodePrivateKeyWif('1CQbfkN8cADaJWk29ARtaa55UNdBa1kLaA');

// Check for errors
if (typeof decodedPrivateKey === 'string') {
  throw new Error('We never reach here as version/length are not checked and function therefore assumes valid');
}
```

An example case where this might become pertinent is when a wallet scans a QR Code and has to distinguish between a WIF (for sweeping) and a Base58 Address (for sending funds to).

This PR does two things:

1. Verifies that the version must be Base58AddressFormatVersion.wif or Base58AddressFormatVersion.wifTestnet
2. Verifies that the length of the payload is either 32 (uncompressed) or 33 (compressed) bytes

**NOTE:** I can't find a formalized spec for WIF and we might want to extend this PR a little bit.

The docs here: https://en.bitcoin.it/wiki/Wallet_import_format

... suggest that BTC might support some additional version codes:

`it should be 0x80, however legacy Electrum or some SegWit vanity address generators may use 0x81-0x87`

... which we might want to add to `Base58AddressFormatVersion` and also validate. Let me know if this is desired, will try to amend (unsure if we should still validate length in that case?).