### PR TITLE
update typicalMaximumVmNumberByteLength & update conditionals

### DIFF
--- a/src/lib/vm/instruction-sets/common/combinators.ts
+++ b/src/lib/vm/instruction-sets/common/combinators.ts
@@ -165,7 +165,10 @@ export const useSixStackItems = <
       ),
   );
 
-const typicalMaximumVmNumberByteLength = 8;
+/**
+ * Zero means any maximum length checks on VM numbers are disabled.
+ */
+const typicalMaximumVmNumberByteLength = 0;
 
 export const useOneVmNumber = <
   State extends AuthenticationProgramStateError &
@@ -356,7 +359,7 @@ export const pushToStackVmNumberChecked = <
   } = {},
 ) => {
   const encoded = bigIntToVmNumber(vmNumber);
-  if (encoded.length > maximumVmNumberByteLength) {
+  if (maximumVmNumberByteLength && encoded.length > maximumVmNumberByteLength) {
     return applyError(
       state,
       AuthenticationErrorCommon.overflowsVmNumberRange,

--- a/src/lib/vm/instruction-sets/common/format.ts
+++ b/src/lib/vm/instruction-sets/common/format.ts
@@ -143,7 +143,7 @@ export const createOpBin2Num =
       state,
       (nextState, [target]) => {
         const minimallyEncoded = bigIntToVmNumber(target);
-        return minimallyEncoded.length > maximumVmNumberByteLength
+        return maximumVmNumberByteLength && minimallyEncoded.length > maximumVmNumberByteLength
           ? applyError(
               nextState,
               AuthenticationErrorCommon.exceededMaximumVmNumberByteLength,

--- a/src/lib/vm/instruction-sets/common/instruction-sets-utils.ts
+++ b/src/lib/vm/instruction-sets/common/instruction-sets-utils.ts
@@ -482,7 +482,10 @@ export const isVmNumberError = (
 ): value is VmNumberError =>
   value === VmNumberError.outOfRange || value === VmNumberError.requiresMinimal;
 
-const typicalMaximumVmNumberByteLength = 8;
+/**
+ * Zero means any maximum length checks on VM numbers are disabled.
+ */
+const typicalMaximumVmNumberByteLength = 0;
 
 /**
  * This method attempts to decode a VM Number, a format in which numeric values
@@ -512,7 +515,8 @@ export const vmNumberToBigInt = (
     requireMinimalEncoding = true,
   }: {
     /**
-     * The maximum valid number of bytes in a VM Number.
+     * The maximum valid number of bytes in a VM Number. Set to `0` to disable
+     * this check.
      */
     maximumVmNumberByteLength?: number;
     /**
@@ -528,7 +532,7 @@ export const vmNumberToBigInt = (
   if (bytes.length === 0) {
     return 0n;
   }
-  if (bytes.length > maximumVmNumberByteLength) {
+  if (maximumVmNumberByteLength && bytes.length > maximumVmNumberByteLength) {
     return VmNumberError.outOfRange;
   }
   // eslint-disable-next-line @typescript-eslint/no-non-null-assertion


### PR DESCRIPTION
We noticed that in libauth v3.1.0-next.4 the function vmNumberToBigInt still has the following logic

`const typicalMaximumVmNumberByteLength = 8;`

where this maximum is the default for `maximumVmNumberByteLength` which then later triggers the error:

```ts
  if (bytes.length > maximumVmNumberByteLength) {
    return VmNumberError.outOfRange;
  }
```

@bitjson suggested setting the `typicalMaximumVmNumberByteLength` to zero to disable maximum length checks

`maximumVmNumberByteLength` appears 144 times in the codebase, sometimes with custom high number value overrides for the BCH consensus for 2025.

I simply updated the defaults and the three inequality checks I found, i did not dive further into the remaining occurrences.